### PR TITLE
[#145] Converted date class to numeric before computing age

### DIFF
--- a/sormas-stats-shinyapp/sormas-stats-app/utils_source_code/case_export.R
+++ b/sormas-stats-shinyapp/sormas-stats-app/utils_source_code/case_export.R
@@ -51,7 +51,7 @@ case_export = function(sormas_db, fromDate, toDate){
     dplyr::left_join(., region, by="region_id") %>% 
     dplyr::left_join(., district, by="district_id") %>% 
     #compute derived variables
-    dplyr::mutate(age=floor(as.numeric(round((reportdate - date_of_birth)/365))), reportweek = lubridate::week(reportdate), 
+    dplyr::mutate(age=floor(as.numeric(reportdate - date_of_birth)/365), reportweek = lubridate::week(reportdate), 
                   reportmonth = lubridate::month(reportdate), reportyear=lubridate::year(reportdate),
                   total = rep(1, nrow(case)) # variable total is added for plotting time series
                   )


### PR DESCRIPTION
This change resolve this error:
``` 

Error in dplyr::mutate(., age = floor(as.numeric(round((reportdate - date_of_birth)/365))), : Problem while computing `age = floor(as.numeric(round((reportdate - date_of_birth)/365)))`. Caused by error in `Ops.Date()`: ! / not defined for "Date" objects
--


 ```